### PR TITLE
Add toprank to Open Source Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The usual marketing tactics don't work on developers. They decide what to use by
 - [CNCF Landscape](https://landscape.cncf.io) - Interactive map of cloud native technologies that many developer tools aim to be listed on.
 - [Hacktoberfest](https://hacktoberfest.com) - Annual October event encouraging open source contributions, used by projects to attract new contributors.
 - [Good First Issues](https://goodfirstissues.com) - Aggregator of beginner-friendly open source issues for attracting new contributors to a project.
+- [Toprank](https://github.com/nowork-studio/toprank) - Open-source Claude Code plugin and skill set for SEO, Google Ads, content writing, and CMS optimization workflows for developer-focused products.
 - [Thanks.dev](https://thanks.dev) - Automated funding distribution to the open source dependencies a project relies on.
 
 ## Product-Led Growth
@@ -324,4 +325,3 @@ The usual marketing tactics don't work on developers. They decide what to use by
 ## Contributing
 
 Please read the [contribution guidelines](contributing.md) before submitting a pull request.
-


### PR DESCRIPTION
Adds `nowork-studio/toprank` to `Open Source Marketing`.

`toprank` is an open-source Claude Code plugin and skill set for SEO, Google Ads, content writing, and CMS optimization workflows.

## Credibility
`nowork-studio/toprank` currently has **115 GitHub stars** and is MIT licensed.

## Why it fits
`toprank` helps open-source and developer-focused products run practical SEO, content, and growth workflows, which fits this list's focus on tools used to market to software developers.

## Disclosure
I am affiliated with this project.

Source: https://github.com/nowork-studio/toprank
